### PR TITLE
Add smoke test: launch snap in VM and capture screenshot

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,4 +1,4 @@
-name: 🧪 Build and smoke test snap
+name: Build and smoke test snap
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: 🔨 Build snap
+    name: Build snap
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +42,7 @@ jobs:
           retention-days: 7
 
   smoke-test:
-    name: 💨 Smoke test (launch + screenshot)
+    name: Smoke test (launch + screenshot)
     runs-on: ubuntu-latest
     needs: build
 
@@ -115,7 +115,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### 🧪 Smoke test ✅
-
-Snap launched in a VM. 📸 Download \`smoke-test-screenshots\` from the [run](${runUrl}) to view.`
+              body: `### Smoke test\n\nSnap launched in a VM. Screenshots available as the \`smoke-test-screenshots\` artifact on the [run](${runUrl}).`
             });

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # fab-agon-emulator-snap
+[![fab-agon-emulator](https://github.com/popey/fab-agon-emulator-snap/actions/workflows/test-snap-can-build.yml/badge.svg)](https://github.com/popey/fab-agon-emulator-snap/actions)
 ## Snap of the Fab Agon Emulator
 
 [![fab-agon-emulator](https://snapcraft.io/fab-agon-emulator/badge.svg)](https://snapcraft.io/fab-agon-emulator)


### PR DESCRIPTION
Adds a second CI job after a successful build that installs the snap into a fresh LXD desktop VM (via [ghvmctl](https://github.com/snapcrafters/ghvmctl)), launches `fab-agon-emulator`, waits 30s, takes screenshots and uploads them as workflow artifacts.

Same approach used by [snapcrafters/ci](https://github.com/snapcrafters/ci).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI smoke test that installs the built snap in a fresh LXD VM, launches `fab-agon-emulator`, and uploads screenshots as artifacts. Also fixes workflow encoding issues and adds a CI badge to the README.

- **New Features**
  - Adds a smoke-test job using `ghvmctl` after build.
  - Installs the snap, launches `fab-agon-emulator`, waits 30s, captures screenshots, and uploads the `smoke-test-screenshots` artifact.
  - Posts a PR comment with a link to the run.
  - Adds a GitHub Actions status badge to the README.

- **Bug Fixes**
  - Removes emojis from workflow names and messages to avoid UTF-8 encoding errors.
  - Minor YAML cleanup.

<sup>Written for commit 9d6a5fba6d71df06edee98b8982b51f052057bd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

